### PR TITLE
Add --version flag to CLI

### DIFF
--- a/resorter_py/cli.py
+++ b/resorter_py/cli.py
@@ -13,6 +13,7 @@ from .ranker import (
     assign_levels,
     assign_custom_quantiles,
 )
+from . import __version__
 
 
 class Config:
@@ -48,6 +49,7 @@ class Config:
 
 
 @click.command()
+@click.version_option(__version__)
 @click.option(
     "--input",
     "input_file",

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -3,6 +3,14 @@ import os
 import pytest
 from click.testing import CliRunner
 from resorter_py.cli import main
+from resorter_py import __version__
+
+def test_cli_version():
+    """Check that --version returns the correct version string."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
 
 def test_cli_interactive_ranking(tmp_path):
     """Scenario 1: One short interactive ranking run."""


### PR DESCRIPTION
This PR adds a `--version` flag to the Click CLI using `click.version_option`. It pulls the version string from `resorter_py.__init__.__version__`.
A new test case in `tests/test_cli_integration.py` verifies that `resorter --version` output contains the correct version number.

Key changes:
- In `resorter_py/cli.py`, added `from . import __version__` and `@click.version_option(__version__)`.
- In `tests/test_cli_integration.py`, added `test_cli_version`.